### PR TITLE
Add version tags

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -141,14 +141,15 @@ contract Registry is Initializable, AccessControlEnumerableUpgradeable {
     address _dev,
     uint64 flags,
     string memory _version,
-    string[] memory _contentURIs
+    string[] memory _contentURIs,
+    string[] memory _tags
   ) external onlyAddPackageRole returns (Repo) {
     Repo repo = Repo(ClonesUpgradeable.clone(repoImplementation));
 
     // Registry must have permissions to create the first version
     repo.initialize(address(this));
 
-    repo.newVersion(_version, _contentURIs);
+    repo.newVersion(_version, _contentURIs, _tags);
 
     // Revoke permissions and grant to dev
     repo.grantRole(repo.DEFAULT_ADMIN_ROLE(), _dev);


### PR DESCRIPTION
Since versions are arbitrary string there must be a way to figure out what's the "latest" version. In current master that's done with `versionSorting`, which indicates how to list the versions and pick the last of this list as latest.

A cleaner and more versatile approach is to use tags, which is what NPM uses.

This PR adds a simple map of tag -> version, which can be used with a standard name "latest" for the above purpose.