### PR TITLE
gas golfing

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -140,9 +140,9 @@ contract Registry is Initializable, AccessControlEnumerableUpgradeable {
     string memory _name,
     address _dev,
     uint64 flags,
-    string memory _version,
-    string[] memory _contentURIs,
-    string[] memory _tags
+    string calldata _version,
+    string[] calldata _contentURIs,
+    string[] calldata _tags
   ) external onlyAddPackageRole returns (Repo) {
     Repo repo = Repo(ClonesUpgradeable.clone(repoImplementation));
 


### PR DESCRIPTION
- Substitute the `stringHash` for the first 32 Bytes of the tag/versions, since i think it's enough to identify both of the fields and it's cheaper.
- Add sanity check to avoid push some tag that points the versionId 0 ( which does not exist).