### PR TITLE
review version tags

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -140,9 +140,9 @@ contract Registry is Initializable, AccessControlEnumerableUpgradeable {
     string memory _name,
     address _dev,
     uint64 flags,
-    string memory _version,
-    string[] memory _contentURIs,
-    string[] memory _tags
+    string calldata _version,
+    string[] calldata _contentURIs,
+    string[] calldata _tags
   ) external onlyAddPackageRole returns (Repo) {
     Repo repo = Repo(ClonesUpgradeable.clone(repoImplementation));
 

--- a/contracts/Repo.sol
+++ b/contracts/Repo.sol
@@ -39,6 +39,7 @@ contract Repo is Initializable, AccessControlEnumerableUpgradeable {
   mapping(bytes32 => uint256) internal versionIdByTag;
 
   event NewVersion(uint256 versionId, string version, string[] contentURIs);
+  event NewTag(string tag, uint256 versionId);
 
   constructor() initializer {}
 
@@ -88,7 +89,7 @@ contract Repo is Initializable, AccessControlEnumerableUpgradeable {
    * @param _versionId version to point _tag to.
    */
   function setTag(string memory _tag, uint256 _versionId) external onlyRole(CREATE_VERSION_ROLE) {
-    require(_versionId < nextIdx, "REPO_INEXISTENT_VERSION");
+    require(_versionId > 0 && _versionId < nextIdx, "REPO_INEXISTENT_VERSION");
     _setTag(_tag, _versionId);
   }
 
@@ -116,6 +117,8 @@ contract Repo is Initializable, AccessControlEnumerableUpgradeable {
   function _setTag(string memory _tag, uint256 _versionId) internal {
     bytes32 tagHash = stringHash(_tag);
     versionIdByTag[tagHash] = _versionId;
+
+    emit NewTag(_tag, _versionId);
   }
 
   function stringHash(string memory version) internal pure returns (bytes32) {

--- a/test/registry.ts
+++ b/test/registry.ts
@@ -81,6 +81,9 @@ describe("Registry", function () {
       "Wrong event NewVersion.contentURIs"
     );
 
+    const newTagEvent = getEvent(newVersionReceipt.events, "NewTag");
+    expect(newTagEvent.args!.tag).to.equal("latest");
+
     // Assert that there are two version in the Repo contract
     await assertRepoVersions(repoWithDev, [newVersion1, newVersion2]);
 
@@ -188,6 +191,9 @@ describe("Registry", function () {
       correctVersion.contentURIs,
       "Wrong event NewVersion.contentURIs"
     );
+
+    const newTagEvent = getEvent(newVersionReceipt.events, "NewTag");
+    expect(newTagEvent.args!.tag).to.equal("latest");
 
     // Assert that there are one version in the Repo contract
     await assertRepoVersions(repoWithDev, [correctVersion]);


### PR DESCRIPTION
- Add `NewTag` event
- Add sanity check to avoid push some tag that points the `versionId` 0 ( which does not exist).